### PR TITLE
Filter by org from tab key

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -187,8 +187,11 @@ func orgsView() tview.Primitive {
 		table.SetCell(row+0, 0, cell)
 	}
 
+	// Set title to indicate filtering
+	title := fmt.Sprintf("Orgs (%d)", len(conf.Orgs))
+
 	flex := tview.NewFlex().SetDirection(tview.FlexRow)
-	flex.SetTitle("Orgs").SetTitleColor(primaryColor).SetBorder(true)
+	flex.SetTitle(title).SetTitleColor(primaryColor).SetBorder(true)
 
 	flex.AddItem(table, 0, 1, false)
 	return flex
@@ -298,7 +301,7 @@ func issuesView() tview.Primitive {
 	})
 
 	// Set title to indicate filtering
-	title := "Issues"
+	title := fmt.Sprintf("Issues (%d)", len(filteredIssues))
 	if len(filteredIssues) != len(issues) {
 		title = fmt.Sprintf("Issues (%d/%d)", len(filteredIssues), len(issues))
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -319,6 +319,7 @@ func searchView() tview.Primitive {
 		SetChangedFunc(func(text string) {
 			// Update search query as user types
 			searchQuery = text
+			RefreshChan <- struct{}{} // Trigger a refresh
 		}).
 		SetDoneFunc(func(key tcell.Key) {
 			// When user finishes input (hits Enter/Esc), hide the search view

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -181,7 +181,8 @@ func orgsView() tview.Primitive {
 		cell := tview.NewTableCell(org)
 		if org == orgFilter {
 			cell.SetBackgroundColor(tcell.ColorWhite).
-				SetTextColor(tcell.ColorBlack)
+				SetTextColor(tcell.ColorBlack).
+				SetExpansion(1)
 		}
 		table.SetCell(row+0, 0, cell)
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -21,6 +21,10 @@ var (
 	searchQuery        = ""
 	useVerticalLayout  = false
 	currentScreenWidth = 0
+	// Colors
+	primaryColor   = tcell.ColorLimeGreen
+	secondaryColor = tcell.ColorDarkOliveGreen
+	grayColor      = tcell.ColorDarkGray
 )
 
 const (
@@ -138,7 +142,7 @@ func orgsView() tview.Primitive {
 	}
 
 	flex := tview.NewFlex().SetDirection(tview.FlexRow)
-	flex.SetTitle("Orgs").SetBorder(true)
+	flex.SetTitle("Orgs").SetTitleColor(primaryColor).SetBorder(true)
 
 	flex.AddItem(table, 0, 1, false)
 	return flex
@@ -238,7 +242,7 @@ func issuesView() tview.Primitive {
 	}
 
 	flex := tview.NewFlex().SetDirection(tview.FlexRow)
-	flex.SetTitle(title).SetBorder(true)
+	flex.SetTitle(title).SetTitleColor(primaryColor).SetBorder(true)
 	flex.AddItem(table, 0, 1, true)
 	return flex
 }
@@ -295,8 +299,9 @@ func shortcutsView() tview.Primitive {
 	}
 
 	return tview.NewTextView().
-		SetText(strings.Join(shortcuts, ", ")).
-		SetTextAlign(tview.AlignCenter)
+		SetText(strings.Join(shortcuts, "    |    ")).
+		SetTextAlign(tview.AlignCenter).
+		SetTextColor(grayColor)
 }
 
 func openBrowser(url string) error {

--- a/internal/tui/utils.go
+++ b/internal/tui/utils.go
@@ -1,0 +1,17 @@
+package tui
+
+func indexOf(list []string, value string) int {
+	for i, v := range list {
+		if v == value {
+			return i
+		}
+	}
+	return -1 // Not found
+}
+
+func fallback(primary string, alt string) string {
+	if primary != "" {
+		return primary
+	}
+	return alt
+}


### PR DESCRIPTION
Fixes #6.

This PR allows the user to cycle through the Orgs view and filter issues
by the selected org.

Shortcuts:

- Tab - Next org
- Escape - Cancel selection

Screenshot: https://github.com/shaunmolloy/bugbox/pull/7#issuecomment-2829020376
