### PR TITLE
Format opened issue text grey to indicate read

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -6,7 +6,7 @@ The BugBox TUI supports the following keyboard shortcuts:
 
 | Key       | Action               | Description                        |
 |-----------|----------------------|------------------------------------|
-| ¿¿        | Navigate             | Move up/down in the issues list    |
+| Up/Down   | Navigate             | Move up/down in the issues list    |
 | Enter     | Open                 | Open selected issue in browser     |
 | /         | Search               | Toggle search mode                 |
 | Tab       | Next Org             | Cycle through organization filters |

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -1,0 +1,21 @@
+# Keyboard Shortcuts
+
+The BugBox TUI supports the following keyboard shortcuts:
+
+## Normal Mode
+
+| Key       | Action               | Description                        |
+|-----------|----------------------|------------------------------------|
+| ¿¿        | Navigate             | Move up/down in the issues list    |
+| Enter     | Open                 | Open selected issue in browser     |
+| /         | Search               | Toggle search mode                 |
+| Tab       | Next Org             | Cycle through organization filters |
+| Esc       | Clear Filter         | Clear the organization filter      |
+| Q         | Quit                 | Exit the application               |
+
+## Search Mode
+
+| Key       | Action               | Description                       |
+|-----------|----------------------|-----------------------------------|
+| Enter     | Search               | Apply search and exit search mode |
+| Esc       | Cancel               | Clear search and exit search mode |

--- a/internal/issues/github/github.go
+++ b/internal/issues/github/github.go
@@ -69,6 +69,7 @@ func FetchIssues(owner string) ([]types.Issue, error) {
 	for i := range result.Items {
 		result.Items[i].Org = owner
 		result.Items[i].Repo = parseRepo(result.Items[i].URL)
+		result.Items[i].Read = false
 	}
 
 	logging.Info(fmt.Sprintf("Found %d issues in org: %s", result.Count, owner))

--- a/internal/issues/github/github.go
+++ b/internal/issues/github/github.go
@@ -15,7 +15,22 @@ const baseURL = "https://api.github.com"
 
 func FetchAllIssues() error {
 	conf, _ := config.LoadConfig()
-	issuesConf := config.Issues{}
+	issuesConf := config.Issues{} // Initialize an empty Issues slice
+
+	// Load existing issues
+	existingIssues, err := config.LoadIssues()
+	if err != nil {
+		logging.Error(fmt.Sprintf("Error loading existing issues: %v", err))
+		return err
+	}
+
+	// Index existing issues by "Org|Repo|ID"
+	existing := make(map[string]types.Issue)
+	for _, i := range existingIssues {
+		i.Repo = parseRepo(i.URL)
+		key := getIssueKey(i)
+		existing[key] = i
+	}
 
 	for _, org := range conf.Orgs {
 		issues, err := FetchIssues(org)
@@ -23,13 +38,23 @@ func FetchAllIssues() error {
 			logging.Error(fmt.Sprintf("Error fetching issues for org %s: %v", org, err))
 		}
 
-		issuesConf = append(issuesConf, issues...)
-
-		if err := config.SaveIssues(issuesConf); err != nil {
-			logging.Error(fmt.Sprintf("Error saving issues for org %s: %v", org, err))
-			return err
+		// Merge with existing issues
+		for _, issue := range issues {
+			// Preserve Read status from existing issues if available
+			issue.Repo = parseRepo(issue.URL)
+			key := getIssueKey(issue)
+			if old, ok := existing[key]; ok {
+				issue.Read = old.Read
+			}
+			issuesConf = append(issuesConf, issue)
 		}
 	}
+
+	if err := config.SaveIssues(issuesConf); err != nil {
+		logging.Error(fmt.Sprintf("Error saving issues: %v", err))
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/issues/github/utils.go
+++ b/internal/issues/github/utils.go
@@ -1,6 +1,11 @@
 package github
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/shaunmolloy/bugbox/internal/types"
+)
 
 // parseRepo extracts the repository name from html_url.
 func parseRepo(url string) string {
@@ -12,4 +17,9 @@ func parseRepo(url string) string {
 		return parts[2]
 	}
 	return ""
+}
+
+// getIssueKey returns a unique key for the issue.
+func getIssueKey(i types.Issue) string {
+	return fmt.Sprintf("%s|%s|%d", i.Org, i.Repo, i.ID)
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -24,6 +24,7 @@ var (
 	orgFilter          = ""
 	useVerticalLayout  = false
 	currentScreenWidth = 0
+	selectedRow        = 1
 	// Colors
 	primaryColor   = tcell.ColorLimeGreen
 	secondaryColor = tcell.ColorDarkOliveGreen
@@ -305,14 +306,24 @@ func issuesView() tview.Primitive {
 
 	// Handle selection - only allow selecting data rows, not the header
 	if len(filteredIssues) > 0 {
-		table.Select(1, 0) // Select first data row by default
+		// Use the remembered selected row if possible
+		if selectedRow < len(filteredIssues)+1 {
+			table.Select(selectedRow, 0)
+		} else {
+			table.Select(1, 0) // Select first data row if previous selection is out of bounds
+			selectedRow = 1
+		}
 	}
 
-	// Custom selection handler to prevent selecting header
+	// Custom selection handler to prevent selecting header and update selected row
 	table.SetSelectionChangedFunc(func(row, column int) {
 		// If header row is selected, move to first data row if available
 		if row == 0 && len(filteredIssues) > 0 {
 			table.Select(1, 0)
+			selectedRow = 1
+		} else if row > 0 {
+			// Update selected row when user navigates
+			selectedRow = row
 		}
 	})
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -320,6 +320,16 @@ func issuesView() tview.Primitive {
 			if err := openBrowser(issue.URL); err != nil {
 				logging.Error(fmt.Sprintf("Failed to open browser: %v", err))
 			}
+
+			// Mark issue as read
+			issue.Read = true
+			issues[row-1] = issue // Update the original issues slice
+			RefreshChan <- struct{}{} // Trigger a refresh
+
+			// Save the updated issues back to the config
+			if err := config.SaveIssues(issues); err != nil {
+				logging.Error(fmt.Sprintf("Failed to save issues: %v", err))
+			}
 		}
 	})
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -268,9 +268,15 @@ func issuesView() tview.Primitive {
 			title = title[:50]
 			break
 		case currentScreenWidth < breakpointLarge:
-			if len(title) > 72 { title = title[:72] }
-			if len(issue.Org) > 15 { issue.Org = issue.Org[:15] }
-			if len(issue.Repo) > 15 { issue.Repo = issue.Repo[:15] }
+			if len(title) > 72 {
+				title = title[:72]
+			}
+			if len(issue.Org) > 15 {
+				issue.Org = issue.Org[:15]
+			}
+			if len(issue.Repo) > 15 {
+				issue.Repo = issue.Repo[:15]
+			}
 			break
 		case len(title) > 120:
 			title = title[:120]
@@ -323,13 +329,14 @@ func issuesView() tview.Primitive {
 
 			// Mark issue as read
 			issue.Read = true
-			issues[row-1] = issue // Update the original issues slice
+			issues[row-1] = issue     // Update the original issues slice
 			RefreshChan <- struct{}{} // Trigger a refresh
 
 			// Save the updated issues back to the config
 			if err := config.SaveIssues(issues); err != nil {
 				logging.Error(fmt.Sprintf("Failed to save issues: %v", err))
 			}
+			logging.Info("Saved issues to config")
 		}
 	})
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -290,6 +290,9 @@ func issuesView() tview.Primitive {
 		cells = append(cells, tview.NewTableCell(createdAt))
 
 		for col, cell := range cells {
+			if issue.Read {
+				cell.SetTextColor(grayColor)
+			}
 			table.SetCell(row+1, col, cell)
 		}
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -9,6 +9,7 @@ type Issue struct {
 	Title     string    `json:"title"`
 	URL       string    `json:"html_url"`
 	Labels    []Label   `json:"labels"`
+	Read      bool      `json:"read"`
 	CreatedAt time.Time `json:"created_at"`
 }
 


### PR DESCRIPTION
Fixes #12

This PR formats the opened issue row with gray text, to indicate it's been read.
From a follow up, we can introduce an R shortcut to toggle the read/unread status.

Updates:

- Show issue row as gray if read
- On issue open, update issue to read
- Prevent fetch overwriting existing issues in config
- Prevent reset of selected issue row on refresh

**Screenshot:** https://github.com/shaunmolloy/bugbox/pull/15#issuecomment-2832646237
