### PR TITLE
Fetch max issues from search API

### DIFF
--- a/internal/issues/github/github.go
+++ b/internal/issues/github/github.go
@@ -13,7 +13,7 @@ import (
 
 const baseURL = "https://api.github.com"
 
-func FetchAllIssues() error {
+func FetchAllIssues(fetchAll bool) error {
 	conf, _ := config.LoadConfig()
 	issuesConf := config.Issues{} // Initialize an empty Issues slice
 
@@ -33,7 +33,7 @@ func FetchAllIssues() error {
 	}
 
 	for _, org := range conf.Orgs {
-		issues, err := FetchIssues(org)
+		issues, err := FetchIssues(org, fetchAll)
 		if err != nil {
 			logging.Error(fmt.Sprintf("Error fetching issues for org %s: %v", org, err))
 		}
@@ -58,45 +58,59 @@ func FetchAllIssues() error {
 	return nil
 }
 
-func FetchIssues(owner string) ([]types.Issue, error) {
+func FetchIssues(owner string, fetchAll bool) ([]types.Issue, error) {
 	logging.Info(fmt.Sprintf("Searching GitHub issues in org: %s", owner))
 	conf, _ := config.LoadConfig()
 
 	query := fmt.Sprintf("org:%s is:issue is:open sort:created-desc", owner)
 	encodedQuery := url.QueryEscape(query)
 
-	api := fmt.Sprintf("%s/search/issues?q=%s", baseURL, encodedQuery)
-	req, err := http.NewRequest("GET", api, nil)
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+	var allIssues []types.Issue
+	page := 1
+
+	for {
+		api := fmt.Sprintf("%s/search/issues?q=%s&per_page=100&page=%d", baseURL, encodedQuery, page)
+		logging.Info(fmt.Sprintf("Fetching %s", api))
+		req, err := http.NewRequest("GET", api, nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+
+		req.Header.Set("Authorization", "token "+conf.GitHubToken)
+		req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("GitHub API error: %s", resp.Status)
+		}
+
+		var result IssueResponse
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			return nil, err
+		}
+
+		// Set Repo & Org for each issue
+		for i := range result.Items {
+			result.Items[i].Org = owner
+			result.Items[i].Repo = parseRepo(result.Items[i].URL)
+			result.Items[i].Read = false
+		}
+
+		allIssues = append(allIssues, result.Items...)
+
+		if !fetchAll || len(result.Items) == 0 || page == 10 {
+			break
+		}
+
+		page++
 	}
 
-	req.Header.Set("Authorization", "token "+conf.GitHubToken)
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GitHub API error: %s", resp.Status)
-	}
-
-	var result IssueResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, err
-	}
-
-	// Set Repo & Org for each issue
-	for i := range result.Items {
-		result.Items[i].Org = owner
-		result.Items[i].Repo = parseRepo(result.Items[i].URL)
-		result.Items[i].Read = false
-	}
-
-	logging.Info(fmt.Sprintf("Found %d issues in org: %s", result.Count, owner))
-	return result.Items, nil
+	logging.Info(fmt.Sprintf("Found %d issues in org: %s", len(allIssues), owner))
+	return allIssues, nil
 }

--- a/internal/issues/github/github.go
+++ b/internal/issues/github/github.go
@@ -70,7 +70,7 @@ func FetchIssues(owner string, fetchAll bool) ([]types.Issue, error) {
 
 	for {
 		api := fmt.Sprintf("%s/search/issues?q=%s&per_page=100&page=%d", baseURL, encodedQuery, page)
-		logging.Info(fmt.Sprintf("Fetching %s", api))
+		logging.Debug(fmt.Sprintf("Fetching %s", api))
 		req, err := http.NewRequest("GET", api, nil)
 		if err != nil {
 			return nil, fmt.Errorf("creating request: %w", err)

--- a/internal/issues/github/utils.go
+++ b/internal/issues/github/utils.go
@@ -1,10 +1,7 @@
 package github
 
 import (
-	"fmt"
 	"strings"
-
-	"github.com/shaunmolloy/bugbox/internal/types"
 )
 
 // parseRepo extracts the repository name from html_url.
@@ -17,9 +14,4 @@ func parseRepo(url string) string {
 		return parts[2]
 	}
 	return ""
-}
-
-// getIssueKey returns a unique key for the issue.
-func getIssueKey(i types.Issue) string {
-	return fmt.Sprintf("%s|%s|%d", i.Org, i.Repo, i.ID)
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -33,6 +33,13 @@ func Info(message string) {
 	}
 }
 
+// Debug logs a debug-level message
+func Debug(message string) {
+	if Logger != nil {
+		Logger.Println("[DEBUG] " + message)
+	}
+}
+
 // Error logs an error-level message
 func Error(message string) {
 	if Logger != nil {

--- a/internal/scheduler/fetch_issues.go
+++ b/internal/scheduler/fetch_issues.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/shaunmolloy/bugbox/internal/issues/github"
 	"github.com/shaunmolloy/bugbox/internal/logging"
+	"github.com/shaunmolloy/bugbox/internal/storage/config"
 	"github.com/shaunmolloy/bugbox/internal/tui"
 )
 
 // FetchIssues starts a goroutine that polls for GitHub issues every minute
 func FetchIssues() {
 	go func() {
-		// Wait 5 seconds before initial fetch to improve startup time
-		time.Sleep(5 * time.Second)
+		config.PruneInvalidOrgs()
 		handleGitHub(true)
 
 		// Then fetch every minute

--- a/internal/scheduler/fetch_issues.go
+++ b/internal/scheduler/fetch_issues.go
@@ -14,19 +14,19 @@ func FetchIssues() {
 	go func() {
 		// Wait 5 seconds before initial fetch to improve startup time
 		time.Sleep(5 * time.Second)
-		handleGitHub()
+		handleGitHub(true)
 
 		// Then fetch every minute
 		ticker := time.NewTicker(1 * time.Minute)
 		for range ticker.C {
-			handleGitHub()
+			handleGitHub(false)
 		}
 	}()
 }
 
-func handleGitHub() {
+func handleGitHub(fetchAll bool) {
 	logging.Info("Fetching GitHub issues...")
-	err := github.FetchAllIssues()
+	err := github.FetchAllIssues(fetchAll)
 	if err != nil {
 		logging.Error(fmt.Sprintf("Fetching error: %v", err))
 		return

--- a/internal/storage/config/issues.go
+++ b/internal/storage/config/issues.go
@@ -18,3 +18,32 @@ func LoadIssues() (Issues, error) {
 	err := LoadFromFile(IssuesPath, &cfg)
 	return cfg, err
 }
+
+// PruneInvalidOrgs removes orgs from issues config no longer in main config
+func PruneInvalidOrgs() error {
+	// Load the current issues configuration
+	issuesConf, err := LoadIssues()
+	if err != nil {
+		return err
+	}
+
+	// Load the current main configuration
+	mainConf, err := LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	validOrgs := make(map[string]struct{}, len(mainConf.Orgs))
+	for _, org := range mainConf.Orgs {
+		validOrgs[org] = struct{}{}
+	}
+
+	// Iterate over the issues configuration and remove invalid orgs
+	for org := range issuesConf {
+		if _, exists := validOrgs[org]; !exists {
+			delete(issuesConf, org)
+		}
+	}
+
+	return SaveIssues(issuesConf)
+}

--- a/internal/storage/config/types.go
+++ b/internal/storage/config/types.go
@@ -7,5 +7,5 @@ type Config struct {
 	Orgs        []string `json:"orgs"`
 }
 
-// Issues represents the hierarchical structure of issues organized by org, repo, and issue number
+// Issues as hierarchical structure of issues organized by org, repo, and id
 type Issues map[string]map[string]map[int]types.Issue

--- a/internal/storage/config/types.go
+++ b/internal/storage/config/types.go
@@ -7,4 +7,5 @@ type Config struct {
 	Orgs        []string `json:"orgs"`
 }
 
-type Issues []types.Issue
+// Issues represents the hierarchical structure of issues organized by org, repo, and issue number
+type Issues map[string]map[string]map[int]types.Issue

--- a/internal/storage/config/utils.go
+++ b/internal/storage/config/utils.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+
+	"github.com/shaunmolloy/bugbox/internal/types"
 )
 
 // IsExist returns true if path exists
@@ -40,4 +42,19 @@ func SaveToFile(path string, data any) error {
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(data)
+}
+
+// FlattenIssues converts the hierarchical issue structure to a flat slice
+func FlattenIssues(issues Issues) []types.Issue {
+	var flat []types.Issue
+
+	for _, repoMap := range issues {
+		for _, issueMap := range repoMap {
+			for _, issue := range issueMap {
+				flat = append(flat, issue)
+			}
+		}
+	}
+
+	return flat
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -18,7 +18,7 @@ var RefreshChan = make(chan struct{}, 1)
 
 // Global state for controlling UI elements
 var (
-	conf, _            = config.LoadConfig()
+	conf               = config.Config{}
 	showSearch         = false
 	searchQuery        = ""
 	orgFilter          = ""
@@ -57,6 +57,7 @@ func Start() error {
 	go func() {
 		for range RefreshChan {
 			logging.Info(fmt.Sprintf("Refreshing TUI. Width: %d", currentScreenWidth))
+			conf, _ = config.LoadConfig()
 			app.QueueUpdateDraw(func() {
 				// Replace the layout with a refreshed one
 				newLayout := layout()


### PR DESCRIPTION
Fixes #9

---

Before, only fetched the first 30 issues for each org.
Now, we fetch the first 1,000 issues for each org.

The full fetch is done on first load. The polling every minute only fetches 1 page of 100 issues.

---

Updates:

- Fetch 1,000 issues on load.
- Fetch 100 issues from polling (minute).
- Prevent clearing existing issues on refetch.
- Prune invalid orgs in issues config: On load, remove orgs from issues config not present in main config.
- Load config from refresh to avoid stale orgs